### PR TITLE
Bruk felles Github worflow v15 for Trivy

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     call-trivy-security-scan:
-        uses: navikt/toi-github-actions-workflows/.github/workflows/trivy-security-scan.yaml@v1
+        uses: navikt/toi-github-actions-workflows/.github/workflows/trivy-security-scan.yaml@v15
         permissions:
             id-token: write
             security-events: write


### PR DESCRIPTION
Er ikke en breaking change i realiteten, tross stort sprang i versjonsnumer. Har gjort samme endring i flere apper før denne.